### PR TITLE
chore: add trailing space to prefixCmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "pytest-grabber.prefixCmd": {
           "type": "string",
           "default": "",
-          "description": "Command to prefix the generated pytest path (e.g., 'pytest '). Include a space!"
+          "description": "Command to prefix the generated pytest path (e.g., 'pytest')."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,10 @@ export function activate(context: vscode.ExtensionContext) {
 			const config = vscode.workspace.getConfiguration('pytest-grabber');
 			const separator = config.get<string>('separator') || '${separator}';
 
-			const prefixCmd = config.get<string>('prefixCmd') || '';
+			let prefixCmd = config.get<string>('prefixCmd') || '';
+			if (!(prefixCmd === '')) {
+				prefixCmd = prefixCmd + ' ';
+			}
 
 			const document = editor.document;
 			const selection = editor.selection;


### PR DESCRIPTION
Very stupid fix to add a space after `prefixCmd`. Could need some improvements.